### PR TITLE
Update `ui` suggested value in error message for turbo.json

### DIFF
--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -587,7 +587,7 @@ pub enum ValidateError {
         concurrency: u32,
     },
     #[error(
-        "Cannot run interactive task \"{task}\" without Terminal UI. Set `\"ui\": true` in \
+        "Cannot run interactive task \"{task}\" without Terminal UI. Set `\"ui\": \"tui\"` in \
          `turbo.json`, use the `--ui=tui` flag, or set `TURBO_UI=true` as an environment variable."
     )]
     InteractiveNeedsUI { task: String },


### PR DESCRIPTION
### Description

Fix error message for `"interactive": true` so it correctly requires
`"ui": "tui"` in `turbo.json`.

### Testing Instructions

1. Set `"interactive": true` for a task without `"ui": "tui"` in `turbo.json`.
2. Run a Turbo command and check the error message.
3. Verify the error message now points to `"ui": "tui"`.